### PR TITLE
Include subdirectory in devtools install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ Install Hadley Wickham's ```devtools```:
 Then, install ```rangeBuilder```:
 
 	require(devtools);
-	install_github("ptitle/rangeBuilder");
+	install_github("ptitle/rangeBuilder/rangeBuilder");
 


### PR DESCRIPTION
Hi! The subdirectory is missing in the installation link in the README ;)
